### PR TITLE
Fix gem name in gemspec to make it downloadable from Github

### DIFF
--- a/bankin.gemspec
+++ b/bankin.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'bankin/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "bankin-api-ruby"
+  spec.name          = "bankin"
   spec.version       = Bankin::VERSION
   spec.authors       = ["Maxim Novichenko"]
   spec.email         = ["maxim@getquipu.com"]


### PR DESCRIPTION
By changing gem name from "bankin-api-ruby" to "bankin" we can download it from Github in Gemfile like this:

```rb
# Gemfile

gem 'bankin', github: 'quipuapp/bankin-api-ruby'
```